### PR TITLE
Separated the build and run stages. Set up multi-stage docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
+FROM node:carbon as build
+WORKDIR /usr/src/app
+COPY . .
+RUN npm install
+RUN npm run build
+
 FROM node:carbon
 WORKDIR /usr/src/app
-COPY package*.json ./
-RUN npm install
-COPY . .
+COPY --from=build /usr/src/app /usr/src/app
+RUN ls .
 EXPOSE 8080
-CMD [ "npm", "run", "serve" ]
+CMD [ "npm", "run", "serve:prod" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN npm run build
 
 FROM node:carbon
 WORKDIR /usr/src/app
-COPY --from=build /usr/src/app /usr/src/app
+COPY --from=build /usr/src/app/package.json /usr/src/app/package.json
+COPY --from=build /usr/src/app/node_modules /usr/src/app/node_modules
+COPY --from=build /usr/src/app/build /usr/src/app/build
 RUN ls .
 EXPOSE 8080
 CMD [ "npm", "run", "serve:prod" ]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Theia web manager
 Web application for managing theia aggregator
+
+# Start the manager
+
+The easiest way to run the manager is to run it as docker container.
+Simply run:
+
+```bash
+docker run -p 8080:8080 theialog/theia-web-manager:latest 
+```

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "start": "run-p client:start server:start",
+    "serve:prod": "node build/server",
     "serve": "npm run build && node build/server",
     "build": "npm install && run-s client:build server:build && mkdir build/logs",
     "server:start": "nodemon -w server --exec \"ENV=development babel-node server\"",


### PR DESCRIPTION
I've updated the Dockerfile and added multi-stage docker build.
This separates the build of the docker image into two stages:
1. First, install all dependencies and build the web manager to production-ready artifacts
2. Then, create new docker image from ```node:carbon``` without the libraries and other artifacts needed during the build and copy only those needed for running the server. Then pack all that into a nice docker image.

However, currently we don't gain much from from multi-stage build because in the second phase, I'm copying node_modules to the new image, and those contain the most data. 
To really gain from the multi-stage build we need to find a way to install only the required libraries:
* Is there a way with npm/node/webpack that we can pack all required minified libs into the build folder?

